### PR TITLE
Add support for DataType to deduce the key

### DIFF
--- a/src/XAMLTools.Core/XAMLCombine/XAMLCombiner.cs
+++ b/src/XAMLTools.Core/XAMLCombine/XAMLCombiner.cs
@@ -393,6 +393,11 @@ namespace XAMLTools.XAMLCombine
                 key = importedElement.Attribute("TargetType")?.Value;
             }
 
+            if (string.IsNullOrEmpty(key))
+            {
+                key = importedElement.Attribute("DataType")?.Value;
+            }
+
             // WinUI / UWP
             if (string.IsNullOrEmpty(key) == false)
             {


### PR DESCRIPTION
According to the documentation over here: https://learn.microsoft.com/en-us/dotnet/api/system.windows.datatemplate.datatype?view=windowsdesktop-8.0 the DataType property also deduces the key value